### PR TITLE
Support on-mount/on-unmount lifecycle methods

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,8 @@
 ; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
-{:deps  {org.clojure/clojurescript {:mvn/version "1.10.520"}}
+{:deps  {org.clojure/clojurescript {:mvn/version "1.10.520"}
+         org.clojure/core.match {:mvn/version "1.0.0"}}
  :paths ["src"]
 
  :aliases

--- a/deps.edn
+++ b/deps.edn
@@ -27,5 +27,11 @@
                 com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}}
    :extra-paths ["test" "test-resources"]
    :main-opts ["-m" "figwheel.main" "-b" "test" "-r"]}
+
+  :test
+  {:extra-paths ["test"]
+   :extra-deps {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
+                                           :sha "209b64504cb3bd3b99ecfec7937b358a879f55c1"}}
+   :main-opts ["-m" "cognitect.test-runner"]}
  }
 }

--- a/deps.edn
+++ b/deps.edn
@@ -13,13 +13,18 @@
 ; limitations under the License.
 {:deps  {org.clojure/clojurescript {:mvn/version "1.10.520"}}
  :paths ["src"]
- :aliases {:build-dev {
-           :extra-deps {com.bhauman/figwheel-main {:mvn/version "0.2.3"}
-                        com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}}
-           :extra-paths ["dev" "resources" "test"]
-           :main-opts ["-m" "figwheel.main" "-b" "dev" "-r"]}
-           :test-dev {
-             :extra-deps {com.bhauman/figwheel-main {:mvn/version "0.2.3"}
-                          com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}}
-             :extra-paths ["test" "test-resources"]
-             :main-opts ["-m" "figwheel.main" "-b" "test" "-r"]}}}
+
+ :aliases
+ {:build-dev
+  {:extra-deps {com.bhauman/figwheel-main {:mvn/version "0.2.3"}
+                com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}}
+   :extra-paths ["dev" "resources" "test"]
+   :main-opts ["-m" "figwheel.main" "-b" "dev" "-r"]}
+
+  :test-dev
+  {:extra-deps {com.bhauman/figwheel-main {:mvn/version "0.2.3"}
+                com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}}
+   :extra-paths ["test" "test-resources"]
+   :main-opts ["-m" "figwheel.main" "-b" "test" "-r"]}
+ }
+}

--- a/deps.edn
+++ b/deps.edn
@@ -11,19 +11,19 @@
 ; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
-{:deps  {org.clojure/clojurescript {:mvn/version "1.10.520"}
+{:deps  {org.clojure/clojurescript {:mvn/version "1.10.773"}
          org.clojure/core.match {:mvn/version "1.0.0"}}
  :paths ["src"]
 
  :aliases
  {:build-dev
-  {:extra-deps {com.bhauman/figwheel-main {:mvn/version "0.2.3"}
+  {:extra-deps {com.bhauman/figwheel-main {:mvn/version "0.2.9"}
                 com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}}
    :extra-paths ["dev" "resources" "test"]
    :main-opts ["-m" "figwheel.main" "-b" "dev" "-r"]}
 
   :test-dev
-  {:extra-deps {com.bhauman/figwheel-main {:mvn/version "0.2.3"}
+  {:extra-deps {com.bhauman/figwheel-main {:mvn/version "0.2.9"}
                 com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}}
    :extra-paths ["test" "test-resources"]
    :main-opts ["-m" "figwheel.main" "-b" "test" "-r"]}

--- a/src/virtua/core.cljs
+++ b/src/virtua/core.cljs
@@ -12,202 +12,55 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 (ns virtua.core
-   (:require [virtua.dom :as dom]
+   (:require [clojure.data :refer [diff]]
+             [virtua.dom :as dom]
              [virtua.events :as evts]
-             [clojure.string :refer [join]]
-             [clojure.data :refer [diff]])
-   (:import [goog.ui IdGenerator]))
+             [virtua.tree :as tree]
+             [virtua.render :refer [render]]))
 
+(defn- apply-state [state decl]
+  (->> decl tree/->tree-seq (tree/expand-tree-seq state)))
 
-(defn- primitive? [x]
-  (or (string? x)
-      (number? x)
-      (= (type x) (type true))))
+(defn- update-render-state
+  [render-state event]
+  (let [[evt-type data el] event]
+    (case evt-type
+      :virtua/add
+      (when-let [on-mount-fn (get-in data [1 :virtua/on-mount])]
+        (swap! render-state update-in [::on-mount-fns] conj [on-mount-fn el]))
 
-(defn- unique-id []
-  (.. IdGenerator getInstance getNextUniqueId))
-
-(defn- create-element
-  [node]
-  (when node
-    (cond
-
-      (primitive? node)
-      (dom/create-text (str node))
-
-      (map? node)
-      (let [{:keys [tag attributes children]} node
-            el (dom/create tag)]
-        (when-not (:id attributes)
-          (dom/set-attribute el "id" (unique-id)))
-        (dom/set-props el attributes)
-        (evts/configure-event-handlers el attributes)
-        (->> children
-             (map create-element)
-             (apply dom/append el)))
-
-      :default
-      (dom/create-text (str node)))))
-
-(defn- merge-attr
-  "Merges attributes, with appropriate joining of merge-able attributes.
-  For example, two maps that define :class will merge their value.
-
-  ```
-  (let [a {:class \"foo\"}
-        b {:class \"bar\"}]
-    (merge-attr a b))
-
-  => {:class \"foo bar\"}
-  ```
-  "
-  [a b]
-  (let [class-a (:class a)
-        class-b (:class b)
-        classes (cond
-                  (and class-a class-b) (str class-a " " class-b)
-                  class-a class-a
-                  class-b class-b)]
-    (cond-> (merge (dissoc a :class) (dissoc b :class))
-      classes (assoc :class classes))))
-
-(defn- extract-keyword-attr
-  "Extracts hiccup-style attributes, namely css class and element ids."
-  [node-type]
-  (let [[element & classes] (.split (name node-type) ".")
-        [etype id] (.split element "#")]
-    [(keyword etype)
-     (cond-> nil
-       (not (empty? classes)) (assoc :class (join " " classes))
-       (not (empty? id)) (assoc :id id))]))
-
-(defn apply-state
-  "Applies state to the given node in the virtual DOM.  The resulting node may
-  contain new children, attributes, etc."
-  [node state]
-  (when node
-    (cond
-      (primitive? node)
-      node
-
-      (fn? node) (apply-state (node state) state)
-
-      (vector? node)
-      (let [[node-type & children] node
-            [tag tag-attr] (extract-keyword-attr node-type)
-            has-attr? (map? (first children))
-            attr (if has-attr?
-                   (merge-attr tag-attr (first children))
-                   tag-attr)
-            children (if has-attr? (rest children) children)]
-        (cond-> {:tag tag}
-
-          attr
-          (assoc :attributes attr)
-
-          (not (empty? children))
-          (assoc :children (->> children
-                                (map #(apply-state % state))
-                                flatten
-                                vec))))
-
-      (coll? node)
-      (map #(apply-state % state) node)
-
-      :default
-      node)))
-
-(defn- changed?
-  "Evaluate the two items to see if they have changed tag type or, if primitive,
-  evaluate if the value has changed."
-  [left right]
-  (and left right
-    (or (not= (:tag left) (:tag right))
-        (and (primitive? left) (not= left right)))))
-
-(defn- attr-changed?
-  "Evaluate the two items to see if the attributes have changed."
-  [left right]
-  (and left right
-       (map? left) (map? right)
-       (not= (:attributes left) (:attributes right))))
-
-(defn- apply-change!
-  [render-state el left right index]
-  (let [old (and left (dom/child-at el index))
-        new (and right (create-element right))]
-
-    (when-let [on-mount-fn (get-in right [:attributes :virtua/on-mount])]
-      (swap! render-state update-in [::on-mount-fns] conj [on-mount-fn el]))
-
-    (when old
-      (when-let [on-unmount-fn (get-in left [:attributes :virtua/on-unmount])]
-        (swap! render-state update-in [::on-unmount-fns] conj on-unmount-fn))
-
-      (dom/remove! old))
-
-    (when new
-      (dom/insert-at el new index))))
-
-(defn- update-elements
-  "Update the elements based on the diff of left and right.  The changes are
-  applied to the provided element, which would be considered their parent. The
-  provided index would be the starting index within the given element's
-  children."
-  [render-state el left right index]
-  (cond
-    (and (not left) right)
-    (apply-change! render-state el left right index)
-
-    (and left (not right))
-    (apply-change! render-state el left right index)
-
-    (changed? left right)
-    (apply-change! render-state el left right index)
-
-    (:children right)
-    (doseq [i (range (max (count (:children left))
-                          (count (:children right))))]
-      (update-elements
-        render-state
-        (dom/child-at el index)
-        (get-in left [:children i])
-        (get-in right [:children i])
-        i)))
-
-  (when (attr-changed? left right)
-    (let [[remove-attrs add-attrs _] (diff (:attributes left) (:attributes right))
-          child (dom/child-at el index)]
-      (dom/update-props child  remove-attrs add-attrs)
-      (evts/update-event-handlers child remove-attrs add-attrs))))
+      :virtua/remove
+      (when-let [on-unmount-fn (get-in data [1 :virtua/on-unmount])]
+        (swap! render-state update-in [::on-unmount-fns] conj on-unmount-fn)))))
 
 (defn- apply-tree-updates
-  [el before after]
+  [el changes]
   (let [render-state (atom {})]
-   (update-elements render-state el before after 0)
+    (render el #(update-render-state render-state %) changes)
 
-   ; Call the on-unmount fn's in order recevied.
-   (doseq [f (-> @render-state ::on-unmount-fns reverse)]
-     (f))
+    ; Call the on-unmount fn's in order recevied.
+    (doseq [f (-> @render-state ::on-unmount-fns reverse)]
+      (f))
 
-   ; Call the on-mount fn's in order received.
-   (doseq [[f el] (-> @render-state
-                      ::on-mount-fns
-                      reverse)]
-     (f el))))
+    ; Call the on-mount fn's in order received.
+    (doseq [[f el] (-> @render-state
+                       ::on-mount-fns
+                       reverse)]
+      (f el))))
 
 (defn- update-tree
   "Update the DOM, using the given virtua tree based on the old state and the
   new state."
-  [el virtua-tree old-state new-state]
+  [el decl old-state new-state]
   ; NOTE, this is pretty inefficient, and could presumably could be optimized
   ; by diffing the state, and then walking the virtua tree for effected
   ; elements.
-  (let [before (apply-state virtua-tree old-state)
-        after (apply-state virtua-tree new-state)
-        [left right same] (diff before after)]
-    (when (and left right)
-      (apply-tree-updates el before after))))
+  (let [changes (diff (apply-state old-state decl)
+                      (apply-state new-state decl))
+        [left right same] changes]
+
+    (when (or left right)
+      (apply-tree-updates el changes))))
 
 (defn- wrap-state
   "Wraps the given state value in an Atom, if necessary."
@@ -244,10 +97,10 @@
   as no state modifier methods are provided."
   [virtua-component value parent]
   (let [state (wrap-state value)
-        initial-node (apply-state virtua-component @state)]
+        initial-node (apply-state @state virtua-component)]
     (dom/remove-children! parent)
     (add-watch state ::virtua-component
                (fn [_ _ old-state new-state]
                  ; TODO: This should probably use requestAnimationFrame
                  (update-tree parent virtua-component old-state new-state)))
-    (apply-tree-updates parent nil initial-node)))
+    (apply-tree-updates parent [nil initial-node nil])))

--- a/src/virtua/dom.cljs
+++ b/src/virtua/dom.cljs
@@ -33,9 +33,12 @@
 
   Note that any event handlers or nil-valued entries are not set."
   [el m]
-  (doseq [[attr v] m]
-    (when (and v (not (event-handler? attr)))
-      (set-attribute el attr v)))
+  (doseq [[attr v] (filter (fn [[k v]]
+                             (and v
+                                  (not (event-handler? k))
+                                  (not= "virtua" (namespace k))))
+                           m)]
+    (set-attribute el attr v))
   el)
 
 (defn remove-props

--- a/src/virtua/render.cljs
+++ b/src/virtua/render.cljs
@@ -1,0 +1,116 @@
+; Copyright 2016-2020 Peter Schwarz
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+(ns virtua.render
+  (:require [clojure.core.match :refer [match]]
+            [virtua.dom :as dom]
+            [virtua.events :as evts]
+            [virtua.tree :refer [tag?]]))
+
+(defn- create-element
+  [node]
+  (when node
+    (if (tag? node)
+      (let [[tag attributes _] node
+            el (dom/create tag)]
+        (dom/set-props el attributes)
+        (evts/configure-event-handlers el attributes)
+        el)
+      (dom/create-text (str node)))))
+
+(defn- child-count [left right same]
+  (letfn [(local-count [node]
+            (if (sequential? node)
+              (last node)
+              0))]
+    (max
+      (local-count left)
+      (local-count right)
+      (local-count same))))
+
+(defn- operations
+  [left right same]
+  (match [left right same]
+    ; no chnage
+    [nil nil _] nil
+
+    [nil new-el nil]
+    [[::add new-el]]
+
+    [old-el nil nil]
+    [[::remove old-el]]
+
+    [old-el new-el nil]
+    [[::remove old-el]
+     [::add new-el]]
+
+    [([nil old-attr & more-old] :seq)
+     ([nil new-attr & more-new] :seq)
+     [tag same-attr _]]
+    [[::change-attr old-attr new-attr]]
+
+    :else nil))
+
+(defn- apply-operations [f el index ops]
+  (doseq [op ops]
+    (let [effect (first op)]
+      (case effect
+        ::remove
+        (let [child (dom/child-at el index)]
+          (f [:virtua/remove (last op) child])
+          (dom/remove! child))
+
+        ::add
+        (let [child (create-element (last op))]
+          (f [:virtua/add (last op) child])
+          (dom/insert-at el child index))
+
+        ::change-attr
+        (let [[_ remove-attrs add-attrs] op
+              child (dom/child-at el index)]
+          (dom/update-props child remove-attrs add-attrs)
+          (evts/update-event-handlers child remove-attrs add-attrs))))))
+
+(defn render
+  ([parent dom-diff] (render parent identity dom-diff))
+  ([parent f dom-diff]
+   (loop [[left right same] dom-diff
+          element-stack (cons [parent 1 0] nil)]
+       (let [node-left (first left)
+             node-right (first right)
+             node-same (first same)]
+         (when (and (or node-left node-right node-same)
+                    (not (empty? element-stack)))
+           (let [[parent nchildren index] (first element-stack)
+                 ops (operations node-left node-right node-same)
+                 _ (apply-operations f parent index ops)
+                 child (dom/child-at parent index)
+
+                 next-nchildren (child-count node-left node-right node-same)
+
+                 new-stack (cond->> (rest element-stack)
+                             (> nchildren (inc index))
+                             (cons [parent nchildren (inc index)])
+
+                             (and child (> next-nchildren 0))
+                             (cons [child next-nchildren 0]))
+
+                 advance (if (and (not child) (> next-nchildren 0))
+                           ; drop old children, if the parent was dropped
+                           next-nchildren
+                           1)]
+
+             (recur [(nthrest left advance)
+                     (nthrest right advance)
+                     (nthrest same advance)]
+                     new-stack)))))))

--- a/src/virtua/tree.cljc
+++ b/src/virtua/tree.cljc
@@ -1,0 +1,116 @@
+; Copyright 2016-2020 Peter Schwarz
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+(ns virtua.tree
+  (:require [clojure.string :refer [join split]]))
+
+(defn- merge-attr
+  "Merges attributes, with appropriate joining of merge-able attributes.
+  For example, two maps that define :class will merge their value.
+
+  ```
+  (let [a {:class \"foo\"}
+        b {:class \"bar\"}]
+    (merge-attr a b))
+
+  => {:class \"foo bar\"}
+  ```
+  "
+  [a b]
+  (let [class-a (:class a)
+        class-b (:class b)
+        classes (cond
+                  (and class-a class-b) (str class-a " " class-b)
+                  class-a class-a
+                  class-b class-b)]
+    (cond-> (merge (dissoc a :class) (dissoc b :class))
+      classes (assoc :class classes))))
+
+(defn- extract-keyword-attr
+  "Extracts hiccup-style attributes, namely css class and element ids."
+  [node-type]
+  (let [[element & classes] (split (name node-type) #"\.")
+        [etype id] (split element #"#")]
+    [(keyword etype)
+     (cond-> nil
+       (not (empty? classes)) (assoc :class (join " " classes))
+       (not (empty? id)) (assoc :id id))]))
+
+(defn tag?
+  "return true if the given value is a tag element declaration.
+
+  This is the format `[:tag ...]`"
+  [v]
+  (and (vector? v) (keyword? (first v))))
+
+(defn markup-branch?
+  [v]
+  (or (tag? v)
+      (sequential? v)
+      (seq? v)))
+
+(defn markup-children
+  [node]
+  (cond
+    ; format [:tag ...]
+    (tag? node)
+    (let [children (subvec node 1)]
+      (if (map? (first children))
+        ; format [:tag {:attributes...}]
+        (subvec children 1)
+        children))
+
+    :default
+    node))
+
+(defn- non-nil-nchildren
+  [coll]
+  (->> coll (filter (complement nil?)) count))
+
+(defn markup-data
+  [node]
+  (cond
+    (tag? node)
+    (let [[tag tag-attr] (extract-keyword-attr (first node))]
+      (if (map? (second node))
+        ; format [:tag {:attributes...}]
+        [tag (merge-attr tag-attr (second node)) (non-nil-nchildren (subvec node 2))]
+        [tag tag-attr (non-nil-nchildren (subvec node 1))]))
+
+    (or (sequential? node) (seq? node))
+    [:virtua/seq nil (non-nil-nchildren node)]
+
+    :default
+    node))
+
+(defn ->tree-seq
+  [vdom]
+  (->>
+    vdom
+    (tree-seq markup-branch? markup-children)
+    (map (fn [node]
+           (if (markup-branch? node)
+             (markup-data node)
+             node)))
+    (filter (complement nil?))))
+
+(defn expand-tree-seq
+  [state t]
+  (for [node t
+        out (if (fn? node)
+              (->> (node state)
+                   ->tree-seq
+                   (expand-tree-seq state))
+              #?(:clj (cons node nil)
+                 :cljs #js [node]))]
+    out))

--- a/test/virtua/core_test.cljs
+++ b/test/virtua/core_test.cljs
@@ -243,8 +243,8 @@
           (is (= "text-danger" (css-class p)))
           (is (= "Text" (text-content p))))))))
 
-(deftest test-on-mount
-  (testing "rendering the dom and providing the mounted dom node to a function"
+(deftest test-life-cycle
+  (testing "rendering the DOM and providing the mounted DOM node to a function"
     (with-container el
       (let [dom-elements (atom {})]
         (v/attach!
@@ -253,6 +253,7 @@
                    "Test On Mount"])
           {} ; empty app state
           el)
+        (is (= 1 (child-count el)))
         (let [el (:dom-el @dom-elements)]
           (is (not (nil? el)))
           (is (= "div" (and el (-> (.-tagName el)
@@ -271,4 +272,20 @@
           {} ; empty app state
           el)
 
-        (is (= [:a :b] @dom-elements))))))
+        (is (= [:a :b] @dom-elements)))))
+
+  (testing "calling on-unmount when DOM node removed"
+    (with-container el
+      (let [app-state (atom {:display true})
+            lifecycle-events (atom {})]
+        (v/attach!
+          (fn [state]
+            [:div (when (:display state)
+                    [:div.child
+                     {:virtua/on-unmount
+                      #(swap! lifecycle-events assoc :removed true)}])])
+          app-state
+          el)
+        (is (= 1 (child-count el)))
+        (swap! app-state assoc :display false)
+        (is (:removed @lifecycle-events))))))

--- a/test/virtua/core_test.cljs
+++ b/test/virtua/core_test.cljs
@@ -15,20 +15,9 @@
   (:require [cljs.test :refer-macros [deftest testing async is are use-fixtures]]
             [virtua.dom :refer [child-at child-count]]
             [virtua.core :as v]
-            [virtua.test-utils :refer-macros [wait with-container]]
-            [goog.dom :as gdom]))
-
-(defn text-content [el]
-  (when el
-    (gdom/getTextContent el)))
-
-(defn tag [el]
-  (when el
-    (.. el -tagName toLowerCase)))
-
-(defn css-class [el]
-  (when el
-    (.. el -className)))
+            [virtua.test-utils
+             :refer [tag text-content css-class]
+             :refer-macros [wait with-container]]))
 
 (deftest test-render-single-element
   (testing "rendering a simple element"

--- a/test/virtua/render_test.cljs
+++ b/test/virtua/render_test.cljs
@@ -166,6 +166,53 @@
         (is (= "text-danger" (css-class p)))
         (is (= "Text" (text-content p)))))))
 
+(deftest test-render-with-pseudo-tag-seq
+  (testing "render with an pseudo-tag for sequences"
+    (with-container el
+      (r/render
+        el
+        [nil
+         '([:ul nil 1]
+           [:virtua/seq nil 3]
+           [:li nil 1] 1
+           [:li nil 1] 2
+           [:li nil 1] 3)])
+
+      (is (= 1 (child-count el)))
+      (let [ul (child-at el 0)]
+        (is (= "ul" (tag ul)))
+        (is (= 3 (child-count ul)))
+
+        (doseq [i (range 1 4)]
+          (let [li (child-at ul (dec i))]
+            (is (= "li" (tag li)))
+            (is (= (str i) (text-content li))))))))
+
+  (testing "render with an pseudo-tag difference"
+    (with-container el
+      (r/render
+        el
+        [nil
+        '([:ul nil 1] [:virtua/seq nil 0])])
+
+      (is (= 1 (child-count el)))
+      (let [ul (child-at el 0)]
+        (is (= "ul" (tag ul)))
+        (is (= 0 (child-count ul)))
+
+        (r/render
+          el
+          [[nil [nil nil 0]]
+           [nil [nil nil 3] [:li nil 1] 1 [:li nil 1] 2 [:li nil 1] 3]
+           [[:ul nil 1] [:virtua/seq nil]]])
+
+        (is (= 3 (child-count ul)))
+
+        (doseq [i (range 1 4)]
+          (let [li (child-at ul (dec i))]
+            (is (= "li" (tag li)))
+            (is (= (str i) (text-content li)))))))))
+
 (deftest test-render-emit
   (testing "render with an add emit"
     (with-container el

--- a/test/virtua/render_test.cljs
+++ b/test/virtua/render_test.cljs
@@ -1,0 +1,207 @@
+(ns virtua.render-test
+  (:require [cljs.test :refer-macros [deftest testing async is are use-fixtures]]
+            [virtua.dom :refer [child-at child-count]]
+            [virtua.render :as r]
+            [virtua.test-utils
+             :refer [css-class tag text-content]
+             :refer-macros [with-container]]))
+
+(deftest test-render-single-element
+  (testing "rendering a simple element"
+    (with-container el
+      (r/render el [nil '([:div nil 1] "hello") nil])
+
+      (is (= 1 (child-count el)))
+      (is (= "div" (tag (child-at el 0))))
+      (is (= "hello" (-> (child-at el 0)
+                         text-content))))))
+
+
+(deftest test-render-nested-elements
+  (testing "rendering nested elements"
+    (with-container el
+      (r/render
+        el
+        [nil
+         '([:div nil 2]
+          [:p nil 1]
+          "paragraph1"
+          [:p nil 1]
+          "paragraph2")
+        nil])
+
+      (is (= 1 (child-count el)))
+      (let [div (child-at el 0)]
+        (is (= "div" (tag div)))
+        (is (= 2 (child-count div)))
+
+        (is (= "paragraph1"
+               (-> (child-at div 0)
+                   text-content)))
+        (is (= "paragraph2"
+               (-> (child-at div 1)
+                   text-content)))))))
+
+(deftest test-render-with-tree-diff
+  (testing "rendering with simple text change"
+    (with-container el
+      ; render first with initial tree
+      (r/render el [nil '([:div nil 1] "Test Text") nil])
+      (is (= 1 (child-count el)))
+      (is (= "div" (tag (child-at el 0))))
+      (is (= "Test Text"
+             (-> (child-at el 0)
+                 text-content)))
+
+      ; render with the text changed
+      (r/render el [[nil "Test Text"] [nil "Changed Text"] [[:div nil 1]]])
+
+      (is (= "Changed Text"
+             (-> (child-at el 0)
+                 text-content))))))
+
+(deftest test-render-with-diff-additive
+  (testing "rendering with an additive difference"
+    (with-container el
+      (r/render el [nil '([:ul nil 2] [:li nil 1] "always shown") nil])
+
+      (is (= 1 (child-count el)))
+      (let [ul (child-at el 0)]
+        (is (= 1 (child-count ul)))
+        (is (= "always shown"
+               (-> (child-at ul 0)
+                   text-content)))
+
+        (r/render
+          el
+          [nil ; old
+           [nil nil nil [:li nil 1] "Now showing: additive"] ; new
+           [[:ul nil 2] [:li nil 1] "always shown"]]) ; same
+
+        (is (= 2 (child-count ul)))
+        (is (= "always shown"
+               (-> (child-at ul 0)
+                   text-content)))
+        (is (= "Now showing: additive"
+               (-> (child-at ul 1)
+                   text-content)))))))
+
+(deftest test-render-with-diff-reductive
+  (testing "rendering with a reductive difference"
+    (with-container el
+      (r/render
+        el
+        [nil
+         '([:ul nil 2]  [:li nil 1] "always shown"  [:li nil 1] "Now showing: reductive")
+         nil])
+      (is (= 1 (child-count el)))
+      (let [ul (child-at el 0)]
+        (is (= 2 (child-count ul)))
+        (is (= "always shown"
+               (-> (child-at ul 0)
+                   text-content)))
+        (is (= "Now showing: reductive"
+               (-> (child-at ul 1)
+                   text-content)))
+
+        (r/render
+         el
+         [[[nil nil 2] nil nil [:li nil 1] "Now showing: reductive"]
+         [[nil nil 1]]
+         [[:ul nil] [:li nil 1] "always shown"]])
+
+        (is (= 1 (child-count ul)))
+        (is (= "always shown"
+               (-> (child-at ul 0)
+                   text-content)))
+        (is (nil? (child-at ul 1)))))))
+
+(deftest test-render-with-diff-insertive
+  (testing "rendering with an insertive difference"
+    (with-container el
+      (r/render
+        el
+        [nil '([:ul nil 1] [:li nil 1] "always shown") nil])
+
+      (is (= 1 (child-count el)))
+      (let [ul (child-at el 0)]
+        (is (= 1 (child-count ul)))
+        (is (= "always shown"
+               (-> (child-at ul 0)
+                   text-content)))
+
+        (r/render
+          el
+          [[[nil nil 1] nil "always shown"]
+           [[nil nil 2] nil "Now showing: insertive" [:li nil 1] "always shown"]
+           [[:ul nil] [:li nil 1]]])
+
+        (is (= 2 (child-count ul)))
+        (is (= "Now showing: insertive"
+               (-> (child-at ul 0)
+                   text-content)))
+        (is (= "always shown"
+               (-> (child-at ul 1)
+                   text-content)))))))
+
+(deftest test-render-with-diff-attribute-change
+  (testing "rendering with an attribute difference"
+    (with-container el
+      (r/render
+        el
+        [nil
+         '([:p  {:class "text-success"} 1] "Text")])
+
+      (is (= 1 (child-count el)))
+      (let [p (child-at el 0)]
+        (is (= "text-success" (css-class p)))
+        (is (= "Text" (text-content p)))
+
+        (r/render
+          el
+          [[[nil {:class "text-success"}]]
+           [[nil {:class "text-danger"}]]
+           [[:p nil 1] "Text"]])
+
+        (is (= "text-danger" (css-class p)))
+        (is (= "Text" (text-content p)))))))
+
+(deftest test-render-emit
+  (testing "render with an add emit"
+    (with-container el
+      (let [events (atom [])]
+        (r/render
+          el
+          #(swap! events conj %)
+          [nil
+           '([:h1 nil 1] "Text")])
+
+        (let [[event el-decl el] (first @events)]
+          (is (= :virtua/add event))
+          (is (= [:h1 nil 1] el-decl))
+          (is (= "h1" (tag el)))))))
+
+  (testing "render with remove emit"
+    (with-container el
+      (let [events (atom [])]
+        (r/render
+          el
+          [nil
+           '([:h1 nil 1] "Text")])
+        ; remove it
+        (r/render
+          el
+          #(swap! events conj %)
+          [[[:h1 nil 1] "Text"]
+           [[:div nil 1] "More text"]
+           nil])
+
+        (let [[event el-decl el] (first @events)]
+          (is (= :virtua/remove event))
+          (is (= [:h1 nil 1] el-decl))
+          (is (= "h1" (tag el))))
+
+        (let [[event el-decl] (get @events 1)]
+          (is (= :virtua/add event))
+          (is (= [:div nil 1] el-decl))
+          (is (= "div" (tag el))))))))

--- a/test/virtua/test_utils.cljs
+++ b/test/virtua/test_utils.cljs
@@ -22,3 +22,15 @@
 
 (defn remove-container! [el]
   (gdom/removeNode el))
+
+(defn text-content [el]
+  (when el
+    (gdom/getTextContent el)))
+
+(defn tag [el]
+  (when el
+    (.. el -tagName toLowerCase)))
+
+(defn css-class [el]
+  (when el
+    (.. el -className)))


### PR DESCRIPTION
This PR adds support for life-cycle methods on-mount and on-unmount, which can be applied to any element.  In order to support this model, rendering needed to be rewritten to support a depth-first walk of the virtual DOM.  This allows for visits to all nodes.

The public API has not changed, but two properties may be added to the attributes of a node, `:virtua/on-mount` and `:virtua/on-unmount`.  The first takes a function that receives real DOM node for the element.  The latter takes no arguments.

